### PR TITLE
Gradienthealth/feature porting segmentation saving and modifications

### DIFF
--- a/extensions/ohif-gradienthealth-extension/src/index.tsx
+++ b/extensions/ohif-gradienthealth-extension/src/index.tsx
@@ -6,6 +6,8 @@ import { id } from './id.js';
 import GoogleSheetsService from './services/GoogleSheetsService';
 import CropDisplayAreaService from './services/CropDisplayAreaService';
 import CacheAPIService from './services/CacheAPIService';
+import overrideNormalizer from './utils/overrideNormalizer';
+import addAutoSegmentationSavingHandler from './utils/addAutoSegmentationSavingHandler';
 
 // import { CornerstoneEventTarget } from '@cornerstonejs/core/CornerstoneEventTarget';
 // import { Events } from '@cornerstonejs/core/Events';
@@ -19,6 +21,14 @@ const gradientHealthExtension = {
   getHangingProtocolModule,
   getPanelModule,
   getViewportModule,
+  onModeEnter({ servicesManager, extensionManager, commandsManager }) {
+    overrideNormalizer();
+    addAutoSegmentationSavingHandler(
+      servicesManager,
+      extensionManager,
+      commandsManager
+    );
+  },
   preRegistration({ servicesManager, commandsManager, extensionManager}) {
     servicesManager.registerService(GoogleSheetsService(servicesManager, commandsManager, extensionManager));
     servicesManager.registerService(CropDisplayAreaService(servicesManager));

--- a/extensions/ohif-gradienthealth-extension/src/index.tsx
+++ b/extensions/ohif-gradienthealth-extension/src/index.tsx
@@ -8,6 +8,7 @@ import CropDisplayAreaService from './services/CropDisplayAreaService';
 import CacheAPIService from './services/CacheAPIService';
 import overrideNormalizer from './utils/overrideNormalizer';
 import addAutoSegmentationSavingHandler from './utils/addAutoSegmentationSavingHandler';
+import addSegmentationBrushSizesHandler from './utils/addSegmentationBrushSizesHandler';
 
 // import { CornerstoneEventTarget } from '@cornerstonejs/core/CornerstoneEventTarget';
 // import { Events } from '@cornerstonejs/core/Events';
@@ -43,6 +44,17 @@ const gradientHealthExtension = {
         return viewCodeSeq[0].CodeValue
       }
     );
+  },
+  getUtilityModule({ servicesManager }) {
+    return [
+      {
+        name: 'common',
+        exports: {
+          addSegmentationBrushSizesHandler:
+            addSegmentationBrushSizesHandler.bind(null, servicesManager),
+        },
+      },
+    ];
   },
 };
 

--- a/extensions/ohif-gradienthealth-extension/src/panels/PanelForm/index.tsx
+++ b/extensions/ohif-gradienthealth-extension/src/panels/PanelForm/index.tsx
@@ -53,7 +53,7 @@ function PanelForm({ servicesManager, extensionManager }) {
   useEffect(() => {
     if(!firstLoad){
       setLoading(true)
-      GoogleSheetsService.writeFormToRow(formValue).then((values)=>{
+      GoogleSheetsService.updateRow(formValue).then((values)=>{
         setLoading(false)
       })
     }

--- a/extensions/ohif-gradienthealth-extension/src/services/CacheAPIService/CacheAPIService.ts
+++ b/extensions/ohif-gradienthealth-extension/src/services/CacheAPIService/CacheAPIService.ts
@@ -1,5 +1,5 @@
 import { DicomMetadataStore, pubSubServiceInterface } from '@ohif/core';
-import { internal } from '@cornerstonejs/dicom-image-loader';
+import { internal, wadouri } from '@cornerstonejs/dicom-image-loader';
 const { getOptions } = internal;
 import _ from 'lodash';
 import {
@@ -10,26 +10,32 @@ import {
   imageLoadPoolManager,
 } from '@cornerstonejs/core';
 
-const LOCAL_EVENTS = {};
+const LOCAL_EVENTS = {
+  IMAGE_CACHE_PREFETCHED: 'event::gradienthealth::image_cache_prefetched',
+};
 
 export default class CacheAPIService {
   listeners: { [key: string]: Function[] };
   EVENTS: { [key: string]: string };
   element: HTMLElement;
+  private servicesManager;
   private commandsManager;
   private extensionManager;
   private dataSource;
   private options;
   public storageUsage;
   public storageQuota;
+  private imageIdToFileUriMap;
 
   constructor(servicesManager, commandsManager, extensionManager) {
     this.listeners = {};
     this.EVENTS = LOCAL_EVENTS;
+    this.servicesManager = servicesManager;
     this.commandsManager = commandsManager;
     this.extensionManager = extensionManager;
     this.storageUsage = null;
     this.storageQuota = null;
+    this.imageIdToFileUriMap = new Map();
     Object.assign(this, pubSubServiceInterface);
   }
 
@@ -122,15 +128,27 @@ export default class CacheAPIService {
   }
 
   public async cacheStudy(StudyInstanceUID, buckets, bucketPrefix) {
+    const { sopClassUids: segSOPClassUIDs } =
+      this.extensionManager.getModuleEntry(
+        '@ohif/extension-cornerstone-dicom-seg.sopClassHandlerModule.dicom-seg'
+      );
     await this.dataSource.retrieve.series.metadata({
       StudyInstanceUID,
       bucketDetails: { buckets, bucketPrefix },
     });
     const study = DicomMetadataStore.getStudy(StudyInstanceUID);
-    const imageIds = study.series.flatMap((serie) =>
-      serie.instances.flatMap((instance) => instance.imageId)
-    );
-    await this.cacheImageIds(imageIds);
+    const imageIds = study.series
+      .filter(
+        (serie) => !segSOPClassUIDs.includes(serie.instances[0].SOPClassUID)
+      )
+      .flatMap((serie) =>
+        serie.instances.flatMap((instance) => instance.imageId)
+      );
+
+    await Promise.all([
+      this.cacheImageIds(imageIds),
+      this.cacheSegFiles(StudyInstanceUID),
+    ]);
   }
 
   public async cacheSeries(StudyInstanceUID, SeriesInstanceUID) {
@@ -152,7 +170,11 @@ export default class CacheAPIService {
       promises.push(promise);
 
       return promise.then(
-        () => {},
+        (imageLoadObject) => {
+          this._broadcastEvent(this.EVENTS.IMAGE_CACHE_PREFETCHED, {
+            imageLoadObject,
+          });
+        },
         (error) => {
           console.error(error);
         }
@@ -179,6 +201,57 @@ export default class CacheAPIService {
     });
 
     await Promise.all(promises);
+  }
+
+  public async cacheSegFiles(studyInstanceUID) {
+    const segSOPClassUIDs = ['1.2.840.10008.5.1.4.1.1.66.4'];
+    const { displaySetService, userAuthenticationService } =
+      this.servicesManager.services;
+
+    const study = DicomMetadataStore.getStudy(studyInstanceUID);
+    const headers = userAuthenticationService.getAuthorizationHeader();
+    const promises = study.series.map((serie) => {
+      const { SOPClassUID, SeriesInstanceUID, url } = serie.instances[0];
+      if (segSOPClassUIDs.includes(SOPClassUID)) {
+        const { scheme, url: parsedUrl } = wadouri.parseImageId(url);
+        if (scheme === 'dicomzip') {
+          return wadouri.loadZipRequest(parsedUrl, url);
+        }
+
+        const displaySet =
+          displaySetService.getDisplaySetsForSeries(SeriesInstanceUID)[0];
+
+        if (this.imageIdToFileUriMap.get(url) === displaySet.instance.imageId) {
+          return;
+        }
+
+        return fetch(parsedUrl, { headers })
+          .then((response) => response.arrayBuffer())
+          .then((buffer) => wadouri.fileManager.add(new Blob([buffer])))
+          .then((fileUri) => {
+            this.imageIdToFileUriMap.set(url, fileUri);
+            displaySet.instance.imageId = fileUri;
+            displaySet.instance.getImageId = () => fileUri;
+          });
+      }
+    });
+
+    await Promise.all(promises);
+  }
+
+  public updateCachedFile(blob, displaySet) {
+    const { url, imageId } = displaySet.instances[0];
+    const fileUri = wadouri.fileManager.add(blob);
+    displaySet.instance.imageId = fileUri;
+    displaySet.instance.getImageId = () => fileUri;
+    displaySet.images[0].imageId = fileUri;
+    displaySet.images[0].getImageId = () => fileUri;
+    this.imageIdToFileUriMap.set(url, fileUri);
+
+    if (imageId?.startsWith('dicomfile:')) {
+      const { url: index } = wadouri.parseImageId(imageId);
+      wadouri.fileManager.remove(index);
+    }
   }
 
   public async cacheMissingStudyImageIds(StudyInstanceUIDs) {

--- a/extensions/ohif-gradienthealth-extension/src/services/CropDisplayAreaService/CropDisplayAreaService.ts
+++ b/extensions/ohif-gradienthealth-extension/src/services/CropDisplayAreaService/CropDisplayAreaService.ts
@@ -1,12 +1,17 @@
 import { pubSubServiceInterface } from '@ohif/core';
-import { 
-    EVENTS as CS_EVENTS,
-    eventTarget as CornerstoneEventTarget,
-    getEnabledElement
+import {
+  EVENTS as CS_EVENTS,
+  eventTarget as CornerstoneEventTarget,
+  getEnabledElement,
+  cache,
 } from '@cornerstonejs/core';
 
 import * as tf from '@tensorflow/tfjs';
-import { IStackViewport } from '@cornerstonejs/core/dist/esm/types';
+import {
+  IStackViewport,
+  IVolumeViewport,
+} from '@cornerstonejs/core/dist/esm/types';
+import { correctZoomFactors, setDisplayArea } from './utils';
 
 const EVENTS = {
     CROP_DISPLAY_AREA_INIT: 'event::gradienthealth::CropDisplayAreaService:init',
@@ -159,5 +164,136 @@ export default class CropDisplayAreaService {
 
     destroy() {
     }
+
+  public async focusToSegment(
+    segmentationId: string,
+    segmentIndex: number
+  ): Promise<void> {
+    const {
+      segmentationService,
+      viewportGridService,
+      cornerstoneViewportService,
+      displaySetService,
+      uiNotificationService,
+    } = this.serviceManager.services;
+
+    const segmentation = segmentationService.getSegmentation(segmentationId);
+    const segDisplayset = displaySetService.getDisplaySetByUID(segmentationId);
+    if (segDisplayset.Modality !== 'SEG') {
+      return;
+    }
+
+    const { imageIds, referencedImageIds } =
+      segmentation?.representationData.Labelmap || {};
+    const referencedDisplaySetInstanceUID =
+      segDisplayset.referencedDisplaySetInstanceUID;
+    const { viewports } = viewportGridService.getState();
+
+    if (!imageIds || !referencedImageIds) {
+      uiNotificationService.show({
+        title: 'Segment focusing',
+        type: 'warning',
+        message: 'No labelmap representationdata found',
+      });
+      return;
+    }
+
+    const viewportsWithSegmentation: IStackViewport | IVolumeViewport = [];
+    viewports.forEach((viewport) => {
+      const cornerstoneViewport =
+        cornerstoneViewportService.getCornerstoneViewport(viewport.viewportId);
+
+      if (
+        viewport.displaySetInstanceUIDs.includes(
+          referencedDisplaySetInstanceUID
+        ) &&
+        cornerstoneViewport?.getCurrentImageId()
+      ) {
+        viewportsWithSegmentation.push(cornerstoneViewport);
+      }
+    });
+
+    if (!viewportsWithSegmentation.length) {
+      uiNotificationService.show({
+        title: 'Segment focusing',
+        type: 'warning',
+        message: 'No viewports found with original orientation',
+      });
+      return;
+    }
+
+    const currentImageId = viewportsWithSegmentation[0].getCurrentImageId();
+    const currentImageIdIndex = viewportsWithSegmentation[0].getSliceIndex();
+    const imageIdIndex = referencedImageIds.findIndex(
+      (referencedImageId) => referencedImageId === currentImageId
+    );
+
+    segmentIndex =
+      segmentIndex || segmentation.segments.findIndex(({ active }) => active);
+
+    const image = cache.getImage(imageIds[imageIdIndex]);
+    const { rows, columns } = image;
+    const dimensions = [columns, rows, imageIds.length];
+    const pixelData = image.getPixelData();
+
+    const mask = tf.tidy(() => {
+      let tensor;
+      tensor = tf.tensor2d(new Float32Array(pixelData), [
+        dimensions[1],
+        dimensions[0],
+      ]);
+
+      return tensor.equal(segmentIndex); // get boolean
+    });
+
+    const maskCoordinates = await tf.whereAsync(mask);
+
+    const { xMax, yMax, xMin, yMin } = tf.tidy(() => {
+      const transpose = tf.einsum('ij->ji', maskCoordinates);
+      tf.dispose(mask);
+      tf.dispose(maskCoordinates);
+
+      let xMin = 0,
+        xMax = dimensions[0],
+        yMin = 0,
+        yMax = dimensions[1];
+
+      if (transpose.size !== 0) {
+        xMin = transpose.gather(1).min().dataSync()[0];
+        xMax = transpose.gather(1).max().dataSync()[0];
+        yMin = transpose.gather(0).min().dataSync()[0];
+        yMax = transpose.gather(0).max().dataSync()[0];
+      }
+
+      return { xMax, yMax, xMin, yMin };
+    });
+
+    let bboxWidth = xMax + 1 - xMin;
+    let bboxHeight = yMax + 1 - yMin;
+    let width = dimensions[0];
+    let height = dimensions[1];
+    const imageAspectRatio = width / height;
+
+    const imagePoint = [
+      (xMax + xMin) / (2 * width),
+      (yMax + yMin) / (2 * height),
+    ] as [number, number];
+    const zoomFactors = {
+      x: bboxWidth / width,
+      y: bboxHeight / height,
+    };
+
+    viewportsWithSegmentation.forEach((viewport) => {
+      const canvasAspectRatio = viewport.sWidth / viewport.sHeight;
+      const zoomFactorsCopy = { ...zoomFactors };
+      correctZoomFactors(zoomFactorsCopy, imageAspectRatio, canvasAspectRatio);
+
+      setDisplayArea(
+        viewport,
+        zoomFactorsCopy,
+        imagePoint,
+        currentImageIdIndex
+      );
+    });
   }
-  
+}

--- a/extensions/ohif-gradienthealth-extension/src/services/CropDisplayAreaService/utils.ts
+++ b/extensions/ohif-gradienthealth-extension/src/services/CropDisplayAreaService/utils.ts
@@ -1,0 +1,40 @@
+import {
+  IStackViewport,
+  IVolumeViewport,
+} from '@cornerstonejs/core/dist/esm/types';
+
+export function setDisplayArea(
+  viewport: IStackViewport | IVolumeViewport,
+  zoomFactors: { x: number; y: number },
+  imagePoint: [number, number],
+  imageIdIndex: number
+) {
+  viewport.setDisplayArea({
+    imageArea: <[number, number]>[zoomFactors.x, zoomFactors.y],
+    imageCanvasPoint: { imagePoint, canvasPoint: <[number, number]>[0.5, 0.5] },
+  });
+  viewport.scroll(imageIdIndex - viewport.getSliceIndex());
+  viewport.render();
+}
+
+export function correctZoomFactors(
+  zoomFactors: { x: number; y: number },
+  imageAspectRatio: number,
+  canvasAspectRatio: number
+) {
+  if (imageAspectRatio < canvasAspectRatio) {
+    zoomFactors.x /= canvasAspectRatio / imageAspectRatio;
+  }
+  if (imageAspectRatio > canvasAspectRatio) {
+    zoomFactors.y /= imageAspectRatio / canvasAspectRatio;
+  }
+
+  if (zoomFactors.x > 0.8 || zoomFactors.y > 0.8) {
+    return;
+  }
+
+  const zoomOutPercentatage = 80;
+
+  zoomFactors.x /= zoomOutPercentatage / 100;
+  zoomFactors.y /= zoomOutPercentatage / 100;
+}

--- a/extensions/ohif-gradienthealth-extension/src/services/GoogleSheetsService/GoogleSheetsService.js
+++ b/extensions/ohif-gradienthealth-extension/src/services/GoogleSheetsService/GoogleSheetsService.js
@@ -1,5 +1,6 @@
 import { DicomMetadataStore, pubSubServiceInterface } from '@ohif/core';
 import { alphabet } from './utils';
+import { addLoadSegmentationsListener } from '../../utils/loadSegmentations';
 
 const MAX_ROWS = 100000;
 
@@ -94,6 +95,17 @@ export default class GoogleSheetsService {
       const { UserAuthenticationService } = this.serviceManager.services;
       this.user = UserAuthenticationService.getUser();
       const params = new URLSearchParams(window.location.search);
+
+      if (
+        ['/segmentation', '/viewer'].some((path) =>
+          window.location.pathname.includes(path)
+        )
+      ) {
+        // Since sheet panel only used by longitudinal, segmentation and breast density mode,
+        // and breast density mode does not handles segmentation we are only loading
+        // segmentations in longitudinal and segmentation mode.
+        addLoadSegmentationsListener(this.serviceManager);
+      }
 
       if (!params.get('sheetId'))
         return this._broadcastEvent(EVENTS.GOOGLE_SHEETS_ERROR);
@@ -228,7 +240,7 @@ export default class GoogleSheetsService {
     });
   }
 
-  async writeFormToRow(formValue) {
+  async updateRow(formValue) {
     const values = this.formHeader.map((colName) => {
       const index = this.formTemplate.findIndex((ele) => {
         return colName == ele.name;
@@ -248,6 +260,14 @@ export default class GoogleSheetsService {
       }
       return null;
     });
+
+    // google sheets is 1-indexed, so take rows[index-1]
+    const updatedFormValue = this.rows[this.index - 1].map((element, index) =>
+      values[index] !== null ? values[index] : element
+    );
+
+    this.rows[this.index - 1] = updatedFormValue;
+    this.formValue = formValue;
 
     await this.writeRange(
       this.sheetId,

--- a/extensions/ohif-gradienthealth-extension/src/utils/addAutoSegmentationSavingHandler.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/addAutoSegmentationSavingHandler.ts
@@ -35,12 +35,12 @@ export default function addAutoSegmentationSavingHandler(
 
       if (!modifiedSegmentationIds.includes(segmentationId)) {
         modifiedSegmentationIds.push(segmentationId);
-      }
 
-      setSegmentationSavingStatus(
-        segmentationId,
-        constants.SAVED_STATUS_ICON.MODIFIED
-      );
+        setSegmentationSavingStatus(
+          segmentationId,
+          constants.SAVED_STATUS_ICON.MODIFIED
+        );
+      }
 
       timerId = setTimeout(() => {
         const datasources = extensionManager.getActiveDataSource();
@@ -59,6 +59,10 @@ export default function addAutoSegmentationSavingHandler(
             throwErrors: true,
           })
             .then((displaySetInstanceUIDs) => {
+              modifiedSegmentationIds.splice(
+                modifiedSegmentationIds.indexOf(modifiedSegmentationId),
+                1
+              );
               if (displaySetInstanceUIDs) {
                 segmentationService.remove(segmentationId);
                 viewportGridService.setDisplaySetsForViewport({

--- a/extensions/ohif-gradienthealth-extension/src/utils/addAutoSegmentationSavingHandler.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/addAutoSegmentationSavingHandler.ts
@@ -1,0 +1,85 @@
+import { createReportAsync } from '@ohif/extension-default';
+
+export default function addAutoSegmentationSavingHandler(
+  servicesManager,
+  extensionManager,
+  commandsManager
+) {
+  const { segmentationService, viewportGridService } = servicesManager.services;
+  const { useSegmentationSavingStatusStore, constants } =
+    extensionManager.getModuleEntry(
+      '@ohif/extension-cornerstone.utilityModule.common'
+    ).exports;
+  const { setSegmentationSavingStatus } =
+    useSegmentationSavingStatusStore.getState();
+
+  let modifiedSegmentationIds: string[] = [],
+    timerId: number;
+  const timoutInSeconds = 5;
+
+  segmentationService.subscribe(
+    segmentationService.EVENTS.SEGMENTATION_DATA_MODIFIED,
+    ({ segmentationId }) => {
+      const segmentation = segmentationService.getSegmentation(segmentationId);
+      if (
+        !Object.values(segmentation.segments).some(
+          (segment) => segment.active && segment.cachedStats.namedStats
+        )
+      ) {
+        // None of the segments is active means this event is triggered not be pixel modifications.
+        // There is no namedStats means it is a new empty segmentation.
+        return;
+      }
+
+      clearTimeout(timerId);
+
+      if (!modifiedSegmentationIds.includes(segmentationId)) {
+        modifiedSegmentationIds.push(segmentationId);
+      }
+
+      setSegmentationSavingStatus(
+        segmentationId,
+        constants.SAVED_STATUS_ICON.MODIFIED
+      );
+
+      timerId = setTimeout(() => {
+        const datasources = extensionManager.getActiveDataSource();
+
+        modifiedSegmentationIds.map((modifiedSegmentationId) =>
+          createReportAsync({
+            servicesManager: servicesManager,
+            getReport: () =>
+              commandsManager.runCommand('storeSegmentation', {
+                segmentationId: modifiedSegmentationId,
+                dataSource: datasources[0],
+                skipLabelDialog: true,
+              }),
+            reportType: 'Segmentation',
+            showLoadingModal: false,
+            throwErrors: true,
+          })
+            .then((displaySetInstanceUIDs) => {
+              if (displaySetInstanceUIDs) {
+                segmentationService.remove(segmentationId);
+                viewportGridService.setDisplaySetsForViewport({
+                  viewportId: viewportGridService.getActiveViewportId(),
+                  displaySetInstanceUIDs,
+                });
+              }
+
+              setSegmentationSavingStatus(
+                modifiedSegmentationId,
+                constants.SAVED_STATUS_ICON.SAVED
+              );
+            })
+            .catch(() => {
+              setSegmentationSavingStatus(
+                modifiedSegmentationId,
+                constants.SAVED_STATUS_ICON.ERROR
+              );
+            })
+        );
+      }, timoutInSeconds * 1000);
+    }
+  );
+}

--- a/extensions/ohif-gradienthealth-extension/src/utils/addSegmentationBrushSizesHandler.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/addSegmentationBrushSizesHandler.ts
@@ -1,0 +1,82 @@
+import { eventTarget, Enums } from '@cornerstonejs/core';
+
+export default function addSegmentationBrushSizesHandler(servicesManager) {
+  eventTarget.addEventListenerOnce(Enums.Events.ELEMENT_ENABLED, (evt) => {
+    evt.detail.element.removeEventListener(
+      Enums.Events.VIEWPORT_NEW_IMAGE_SET,
+      (evt) => overrideSegmentationSizes(servicesManager)
+    );
+    evt.detail.element.addEventListener(
+      Enums.Events.VIEWPORT_NEW_IMAGE_SET,
+      (evt) => overrideSegmentationSizes(servicesManager)
+    );
+  });
+}
+
+export function overrideSegmentationSizes(servicesManager) {
+  const { toolbarService } = servicesManager.services;
+
+  const modifyingButtons = { Brush: 'brush-radius', Eraser: 'eraser-radius' };
+
+  const buttons = Object.keys(modifyingButtons).map((buttonId) =>
+    toolbarService.getButton(buttonId)
+  );
+
+  const params = new URLSearchParams(window.location.search);
+  const defaultBrushSizeInMm = +params.get('defaultBrushSize') || 2;
+  let minBrushSizeInMm = +params.get('minBrushSize') || 2;
+  let maxBrushSizeInMm = +params.get('maxBrushSize') || 3;
+
+  const highestPixelSpacing = getPixelToMmConversionFactor(servicesManager);
+
+  if (!highestPixelSpacing) {
+    return;
+  }
+
+  const lowestBrushRadius = highestPixelSpacing / 2;
+
+  if (minBrushSizeInMm < lowestBrushRadius) {
+    minBrushSizeInMm = lowestBrushRadius;
+  }
+  if (maxBrushSizeInMm < lowestBrushRadius) {
+    maxBrushSizeInMm = highestPixelSpacing;
+  }
+
+  const min = +minBrushSizeInMm.toFixed(2);
+  const max = +maxBrushSizeInMm.toFixed(2);
+  const defaultValue = defaultBrushSizeInMm;
+  const step = +((maxBrushSizeInMm - minBrushSizeInMm) / 100).toFixed(2);
+
+  buttons.forEach((button) => {
+    const radiusOption = button.props.options.find(
+      ({ id }) => id === modifyingButtons[button.id]
+    );
+
+    if (!radiusOption) {
+      return;
+    }
+
+    radiusOption.min = min;
+    radiusOption.max = max;
+    radiusOption.value = defaultValue;
+    radiusOption.step = step;
+  });
+
+  toolbarService.addButtons(buttons, true);
+}
+
+function getPixelToMmConversionFactor(servicesManager) {
+  const { viewportGridService, cornerstoneViewportService } =
+    servicesManager.services;
+  const { activeViewportId } = viewportGridService.getState();
+  const viewport =
+    cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
+  const imageData = viewport?.getImageData();
+
+  if (!imageData) {
+    return;
+  }
+
+  const { spacing } = imageData;
+  return Math.max(spacing[0], spacing[1]);
+}

--- a/extensions/ohif-gradienthealth-extension/src/utils/loadSegmentations.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/loadSegmentations.ts
@@ -1,0 +1,128 @@
+import { eventTarget, Enums, cache } from '@cornerstonejs/core';
+
+export function addLoadSegmentationsListener(servicesManager) {
+  eventTarget.addEventListener(Enums.Events.ELEMENT_ENABLED, (evt) => {
+    evt.detail.element.removeEventListener(
+      Enums.Events.VIEWPORT_NEW_IMAGE_SET,
+      (evt) => loadSegmentations(servicesManager, evt.detail.viewportId)
+    );
+    evt.detail.element.addEventListener(
+      Enums.Events.VIEWPORT_NEW_IMAGE_SET,
+      (evt) => loadSegmentations(servicesManager, evt.detail.viewportId)
+    );
+  });
+}
+
+function loadSegmentations(
+  serviceManager: {
+    services: {
+      segmentationService: any;
+      displaySetService: any;
+      UserAuthenticationService: any;
+      CacheAPIService: any;
+      viewportGridService: any;
+    };
+  },
+  viewportId: string
+) {
+  const params = new URLSearchParams(window.location.search);
+  const studyInstanceUID = params.get('StudyInstanceUIDs');
+
+  const segSOPClassUIDs = ['1.2.840.10008.5.1.4.1.1.66.4'];
+  const {
+    segmentationService,
+    displaySetService,
+    UserAuthenticationService,
+    CacheAPIService,
+    viewportGridService,
+  } = serviceManager.services;
+  const headers = UserAuthenticationService.getAuthorizationHeader();
+  const viewport = viewportGridService.getViewportState(viewportId);
+
+  // TODO: need to filter the displaysets to the series loaded in the viewport
+  const viewportSegDisplaySets = displaySetService.getDisplaySetsBy(
+    (ds: {
+      StudyInstanceUID: any;
+      SOPClassUID: string;
+      referencedDisplaySetInstanceUID: string;
+    }) =>
+      ds.StudyInstanceUID === studyInstanceUID &&
+      segSOPClassUIDs.includes(ds.SOPClassUID) &&
+      viewport.displaySetInstanceUIDs.includes(
+        ds.referencedDisplaySetInstanceUID
+      )
+  );
+  const nonSegImageIds = displaySetService
+    .getDisplaySetsBy(
+      (ds: { StudyInstanceUID: any; SOPClassUID: string }) =>
+        ds.StudyInstanceUID === studyInstanceUID &&
+        !segSOPClassUIDs.includes(ds.SOPClassUID)
+    )
+    .flatMap((ds: { images: any[] }) =>
+      ds.images.flatMap((image: { imageId: any }) => image.imageId)
+    );
+
+  const isAllSegmentationsLoaded = viewportSegDisplaySets.every(
+    (ds: { isLoaded: boolean }) => ds.isLoaded
+  );
+
+  if (isAllSegmentationsLoaded) {
+    return;
+  }
+
+  const isAllSeriesOfStudyCached = () => {
+    return nonSegImageIds.every((imageId: any) =>
+      cache.getImageLoadObject(imageId)
+    );
+  };
+
+  let unsubscribe: () => void;
+
+  const loadSegmentations = async () => {
+    if (isAllSeriesOfStudyCached()) {
+      const loadPromises = viewportSegDisplaySets.map(
+        async (displaySet: {
+          getReferenceDisplaySet: () => void;
+          load: (arg0: { headers: any }) => any;
+        }) => {
+          //   displaySet.getReferenceDisplaySet();
+          return displaySet.load({ headers });
+        }
+      );
+
+      await Promise.all(loadPromises);
+
+      const addRepresentationPromises = viewportSegDisplaySets.map(
+        async (displaySet: { displaySetInstanceUID: string }) =>
+          await segmentationService.addSegmentationRepresentation(viewportId, {
+            segmentationId: displaySet.displaySetInstanceUID,
+          })
+      );
+
+      Promise.all(addRepresentationPromises).then(() => {
+        const segmentationsOfLoadedImage = displaySetService.getDisplaySetsBy(
+          (ds: { referencedDisplaySetInstanceUID: string }) =>
+            ds.referencedDisplaySetInstanceUID ===
+            viewport.displaySetInstanceUIDs[0]
+        );
+
+        // we are setting first segmentation of the image in the active viewport as active.
+        segmentationService.setActiveSegmentation(
+          viewportId,
+          segmentationsOfLoadedImage[0].displaySetInstanceUID
+        );
+      });
+
+      unsubscribe?.();
+    }
+  };
+
+  if (isAllSeriesOfStudyCached()) {
+    loadSegmentations();
+  } else {
+    ({ unsubscribe } = CacheAPIService.subscribe(
+      CacheAPIService.EVENTS.IMAGE_CACHE_PREFETCHED,
+      loadSegmentations
+    ));
+  }
+}

--- a/extensions/ohif-gradienthealth-extension/src/utils/overrideNormalizer.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/overrideNormalizer.ts
@@ -1,0 +1,137 @@
+import { normalizers } from 'dcmjs';
+import { metaData } from '@cornerstonejs/core';
+
+const { Normalizer, ImageNormalizer } = normalizers;
+
+export default function overrideNormalizer() {
+  class SingleSliceImageNormalizer extends ImageNormalizer {
+    normalize() {
+      this.dataset = getHandledSingleImageDataset(this.datasets[0], metaData);
+      super.normalizeMultiframe();
+    }
+  }
+
+  const XAImageNormalizer = SingleSliceImageNormalizer;
+  const MGImageNormalizer = SingleSliceImageNormalizer;
+  const USImageNormalizer = SingleSliceImageNormalizer;
+  const CRImageNormalizer = SingleSliceImageNormalizer;
+
+  class SecondaryCapturedImageNormalizer extends ImageNormalizer {
+    normalize() {
+      let normalizerClass: { new (datasets) };
+      switch (this.dataSets[0].Modality) {
+        case 'MG':
+          normalizerClass = Normalizer.normalizerForSOPClassUID(
+            '1.2.840.10008.5.1.4.1.1.1.2'
+          );
+          break;
+        case 'XA':
+          normalizerClass = Normalizer.normalizerForSOPClassUID(
+            '1.2.840.10008.5.1.4.1.1.12.1'
+          );
+          break;
+        case 'US':
+          normalizerClass = Normalizer.normalizerForSOPClassUID(
+            '1.2.840.10008.5.1.4.1.1.6.1'
+          );
+          break;
+        case 'CR':
+          normalizerClass = Normalizer.normalizerForSOPClassUID(
+            '1.2.840.10008.5.1.4.1.1.1'
+          );
+          break;
+        default:
+          super.normalize();
+          return;
+      }
+
+      const normalizer = new normalizerClass(this.dataSets);
+      normalizer.normalize();
+    }
+  }
+
+  const SingleImageSOPClassUIDMap: Record<string, any> = {
+    '1.2.840.10008.5.1.4.1.1.1.2': MGImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.1.2.1': MGImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.13.1.3': MGImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.12.1': XAImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.7': SecondaryCapturedImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.6.1': USImageNormalizer,
+    '1.2.840.10008.5.1.4.1.1.1': CRImageNormalizer,
+  };
+
+  const parentNormalizerForSOPClassUID = Normalizer.normalizerForSOPClassUID;
+  Normalizer.normalizerForSOPClassUID = (sopClassUID: string) => {
+    const normalizerClass = parentNormalizerForSOPClassUID(sopClassUID);
+
+    if (normalizerClass) {
+      return normalizerClass;
+    } else if (SingleImageSOPClassUIDMap[sopClassUID]) {
+      return SingleImageSOPClassUIDMap[sopClassUID];
+    }
+  };
+}
+
+function getHandledSingleImageDataset(dataset, metaData) {
+  const { rowCosines, columnCosines } = metaData.get(
+    'imagePlaneModule',
+    dataset.imageId
+  );
+
+  const PerFrameFunctionalGroupsSequence = {
+    PlanePositionSequence: {
+      ImagePositionPatient: dataset.ImagePositionPatient || [0, 0, 0],
+    },
+    FrameVOILUTSequence: {
+      WindowCenter: dataset.WindowCenter,
+      WindowWidth: dataset.WindowWidth,
+    },
+    PlaneOrientationSequence: {
+      ImageOrientationPatient: dataset.ImageOrientationPatient || [
+        ...rowCosines,
+        ...columnCosines,
+      ],
+    },
+  };
+
+  return {
+    ...dataset,
+    ReferencedSeriesSequence: {
+      SeriesInstanceUID: dataset.SeriesInstanceUID,
+      ReferencedInstanceSequence: [
+        {
+          ReferencedSOPClassUID: dataset.SOPClassUID,
+          ReferencedSOPInstanceUID: dataset.SOPInstanceUID,
+        },
+      ],
+    },
+    SharedFunctionalGroupsSequence: {
+      PlaneOrientationSequence: {
+        ImageOrientationPatient: dataset.ImageOrientationPatient || [
+          ...rowCosines,
+          ...columnCosines,
+        ],
+      },
+      PixelMeasuresSequence: {
+        PixelSpacing: dataset.PixelSpacing,
+        SpacingBetweenSlices: 0,
+        SliceThickness: 0,
+      },
+      PixelValueTransformationSequence: {
+        RescaleIntercept: dataset.RescaleIntercept,
+        RescaleSlope: dataset.RescaleSlope,
+        RescaleType: dataset.RescaleType,
+      },
+    },
+    PerFrameFunctionalGroupsSequence:
+      dataset.NumberOfFrames > 1
+        ? Array(dataset.NumberOfFrames).fill(PerFrameFunctionalGroupsSequence)
+        : PerFrameFunctionalGroupsSequence,
+    NumberOfFrames: dataset.NumberOfFrames || 1,
+    ImageOrientationPatient: dataset.ImageOrientationPatient || [
+      ...rowCosines,
+      ...columnCosines,
+    ],
+    ImagePositionPatient: dataset.ImagePositionPatient || [0, 0, 0],
+  };
+}


### PR DESCRIPTION
* Gradienthealth/feature porting segmentation saving

  * Overrided the dcmjs Normalizer to support some single slice Modalities

  * Supported auto segmentation saving

  * Supported segmentation caching and auto segmentation loading with sheets

  * Added a function to update the segmentation file in the fileManager cache

* Gradienthealth/feature porting segmentation modifications

  * Filtered saved segmentations in auto segmentation saving handler

  * Handle min, max and default segmentation brush sizes through url params

  * Supports segment focusing by zoom/ pan