### PR TITLE
Fix PHI bounding box label numbering to handle index gaps

### DIFF
--- a/extensions/ohif-gradienthealth-extension/src/utils/phiBoundingBoxMeasurementUtils.ts
+++ b/extensions/ohif-gradienthealth-extension/src/utils/phiBoundingBoxMeasurementUtils.ts
@@ -34,16 +34,28 @@ export function addAutoPHIBoundingBoxToolLabeler(servicesManager) {
         return;
       }
 
-      const phiMeasurementsCount = measurementService.getMeasurements(
-        (m) => m.toolName === phiBoundingBoxToolName
-      ).length;
+      const otherPhiMeasurements = measurementService.getMeasurements(
+        // Exclude the current measurement to avoid self-referencing during the add event
+        (m) =>
+          m.toolName === phiBoundingBoxToolName && m.uid !== measurement.uid
+      );
+
+      const usedIndices = new Set();
+      otherPhiMeasurements.forEach((m) => {
+        const match = m.label && m.label.match(/PHI Bounding Box (\d+)/);
+        if (match) {
+          usedIndices.add(parseInt(match[1], 10));
+        }
+      });
+
+      let nextIndex = 1;
+      while (usedIndices.has(nextIndex)) {
+        nextIndex++;
+      }
 
       measurementService.update(
         measurement.uid,
-        {
-          ...measurement,
-          label: `PHI Bounding Box ${phiMeasurementsCount}`,
-        },
+        { ...measurement, label: `PHI Bounding Box ${nextIndex}` },
         true
       );
     }


### PR DESCRIPTION
## Summary
- Changed PHI bounding box labeling to track used indices instead of counting total measurements
- Ensures labels fill gaps when measurements are deleted

## Changes
- Replace count-based numbering with index-based tracking
- Parse existing labels to find which indices are in use
- Assign next available index to new measurements